### PR TITLE
CI: Update config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
 sudo: false
-env:
-  - NODE_VERSION=0.10
-  - NODE_VERSION=0.12
-  - NODE_VERSION=iojs
+
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "6"
+  - "stable"
 
 before_install:
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
-  - "npm config set spin false"
-
-os:
-  - osx
-  - linux
-script: npm run test
-install:
-  - test $TRAVIS_OS_NAME = "osx" && brew install nvm && source $(brew --prefix nvm)/nvm.sh || test $TRAVIS_OS_NAME = "linux"
-  - nvm install $NODE_VERSION
-  - node --version
-  - npm --version
-  - git --version
-  - npm install
-
-after_script:
-  - cat coverage/lcov.info | codeclimate
-  - cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js
+  # prevent the npm loading indicator
+  - npm config --global set spin false


### PR DESCRIPTION
- nvm is setup by default for "language: node_js"
- iojs is obsolete
- there is neither codeclimate nor coveralls installed
- node, npm and git versions are posted by default on Travis
- testing on OSX seems unnecessary

Resolves #2 

/cc @stefanpenner 
